### PR TITLE
clearly separate the validation and processing

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 98%    # the required coverage value
+        threshold: 0.1%  # the leniency in hitting the target


### PR DESCRIPTION
This refactoring more clearly defines the json validation and ingestion steps of loading a json. Should now be easy to hook in the `analysis_schema` when ready. 

This PR addresses the last item in #1 