### PR TITLE
set layer name, metadata, loop over fields

### DIFF
--- a/src/yt_napari/_model_ingestor.py
+++ b/src/yt_napari/_model_ingestor.py
@@ -1,37 +1,56 @@
+from typing import List, Tuple
+
 import numpy as np
 import yt
 
 from yt_napari._data_model import InputModel
 
+Layer = Tuple[np.ndarray, dict, str]
 
-def _process_validated_model(model: InputModel) -> np.ndarray:
+
+def _process_validated_model(model: InputModel) -> List[Layer]:
+    # return a list of napari layer-tuples
+
+    layer_list = []
 
     # our model is already validated, so we can assume the fields exist with
     # their correct types. This is all the yt-specific code required to load a
     # dataset and return a plain numpy array
 
     ds = yt.load(model.dataset)
-    field = (model.field_type, model.field_name)
 
-    # get the left, right edge as a unitful array
-    LE = ds.arr(model.left_edge, model.edge_units)
-    RE = ds.arr(model.right_edge, model.edge_units)
-
-    # create the fixed resolution buffer
-    frb = ds.r[
-        LE[0] : RE[0] : complex(0, model.resolution[0]),  # noqa: E203
-        LE[1] : RE[1] : complex(0, model.resolution[1]),  # noqa: E203
-        LE[2] : RE[2] : complex(0, model.resolution[2]),  # noqa: E203
+    field_list = [
+        (model.field_type, model.field_name),
     ]
 
-    data = frb[field]  # extract the field (the slow part)
+    for field in field_list:
+        # get the left, right edge as a unitful array
+        LE = ds.arr(model.left_edge, model.edge_units)
+        RE = ds.arr(model.right_edge, model.edge_units)
 
-    if model.take_log:
-        return np.log10(data)
-    return data
+        # create the fixed resolution buffer
+        frb = ds.r[
+            LE[0] : RE[0] : complex(0, model.resolution[0]),  # noqa: E203
+            LE[1] : RE[1] : complex(0, model.resolution[1]),  # noqa: E203
+            LE[2] : RE[2] : complex(0, model.resolution[2]),  # noqa: E203
+        ]
+
+        data = frb[field]  # extract the field (the slow part)
+        if model.take_log:
+            data = np.log10(data)
+
+        # writing the full pydanctic model dict to the metadata attribute for
+        # now -- this does not actually seem to get displayed though.
+        fieldname = ":".join(field)
+        add_kwargs = {"name": fieldname, "metadata": model.dict()}
+        layer_type = "image"
+
+        layer_list.append((data, add_kwargs, layer_type))
+
+    return layer_list
 
 
-def load_from_json(json_path: str):
+def load_from_json(json_path: str) -> List[Layer]:
 
     # InputModel is a pydantic class, the following will validate the json
     model = InputModel.parse_file(json_path)

--- a/src/yt_napari/_reader.py
+++ b/src/yt_napari/_reader.py
@@ -80,7 +80,4 @@ def reader_function(path):
     if not isinstance(path, str):
         raise NotImplementedError("schema loader only supports a single path")
 
-    data = load_from_json(path)  # the data
-    add_kwargs = {}  # optional kwargs for the viewer.add_* method
-    layer_type = "image"  # optional, default is "image"
-    return [(data, add_kwargs, layer_type)]
+    return load_from_json(path)


### PR DESCRIPTION
The napari image layer name is now set to `field_type:field_name`, metadata dict is set to the dict representation of the validated json (though it doesn't seem to be displayed by napari anywhere) and the actual yt read now has a loop over fields (though the json does not actually accept multiple fields yet). This will close #15 and is a step to #9.