### PR TITLE
GUI widget

### DIFF
--- a/src/yt_napari/_data_model.py
+++ b/src/yt_napari/_data_model.py
@@ -15,9 +15,9 @@ class Field(BaseModel):
 
 class SelectionObject(BaseModel):
     fields: List[Field]
-    left_edge: Optional[Tuple[float, float, float]] = [0.0, 0.0, 0.0]
-    right_edge: Optional[Tuple[float, float, float]] = [1.0, 1.0, 1.0]
-    resolution: Optional[Tuple[int, int, int]] = [400, 400, 400]
+    left_edge: Optional[Tuple[float, float, float]] = (0.0, 0.0, 0.0)
+    right_edge: Optional[Tuple[float, float, float]] = (1.0, 1.0, 1.0)
+    resolution: Optional[Tuple[int, int, int]] = (400, 400, 400)
 
 
 class DataContainer(BaseModel):

--- a/src/yt_napari/_gui_utilities.py
+++ b/src/yt_napari/_gui_utilities.py
@@ -1,0 +1,268 @@
+import warnings
+from collections import defaultdict
+from typing import Callable, Optional, Tuple, Union
+
+import pydantic
+from magicgui import type_map, widgets
+
+from yt_napari import _data_model
+
+
+def add_pydantic_to_container(
+    py_model: Union[pydantic.BaseModel, pydantic.main.ModelMetaclass],
+    container: widgets.Container,
+):
+    # recursively traverse a pydantic model adding widgets to a container. When a nested
+    # pydantic model is encountered, add a new nested container
+    for field, field_def in py_model.__fields__.items():
+        ftype = field_def.type_
+        if isinstance(ftype, pydantic.BaseModel) or isinstance(
+            ftype, pydantic.main.ModelMetaclass
+        ):
+            # the field is a pydantic class, add a container for it and fill it
+            new_widget_cls = widgets.Container
+            new_widget = new_widget_cls(name=field_def.name)
+            add_pydantic_to_container(ftype, new_widget)
+        elif translator.is_registered(py_model, field):
+            new_widget = translator.get_widget_instance(py_model, field)
+        else:
+            # use a magicgui default
+            new_widget_cls, ops = type_map.get_widget_class(
+                None, ftype, dict(name=field_def.name, value=field_def.default)
+            )
+            new_widget = new_widget_cls(**ops)
+            if isinstance(new_widget, widgets.EmptyWidget):
+                msg = "magicgui could not identify a widget for "
+                msg += f" {py_model}.{field}, which has type {ftype}"
+                warnings.warn(message=msg)
+        container.append(new_widget)
+
+
+def get_pydantic_kwargs(container: widgets.Container, py_model, pydantic_kwargs: dict):
+    # given a container that was instantiated from a pydantic model, get the arguments
+    # needed to instantiate that pydantic model from the container.
+
+    # traverse model fields, pull out values from container
+    for field, field_def in py_model.__fields__.items():
+        ftype = field_def.type_
+        if isinstance(ftype, pydantic.BaseModel) or isinstance(
+            ftype, pydantic.main.ModelMetaclass
+        ):
+            new_kwargs = {}  # new dictionary for the new nest level
+            # any pydantic class will be a container, so pull that out to pass
+            # to the recursive call
+            sub_container = getattr(container, field_def.name)
+            get_pydantic_kwargs(sub_container, ftype, new_kwargs)
+            if "typing.List" in str(field_def.outer_type_):
+                new_kwargs = [
+                    new_kwargs,
+                ]
+            pydantic_kwargs[field] = new_kwargs
+
+        elif translator.is_registered(py_model, field):
+            widget_instance = getattr(container, field_def.name)  # pull from container
+            pydantic_kwargs[field] = translator.get_pydantic_attr(
+                py_model, field, widget_instance
+            )
+        else:
+            # not a pydantic class, just pull the field value from the container
+            if hasattr(container, field_def.name):
+                value = getattr(container, field_def.name).value
+                pydantic_kwargs[field] = value
+
+
+def set_default(variable, default):
+    if variable is None:
+        return default
+    return variable
+
+
+class MagicPydanticRegistry:
+
+    registry = defaultdict(dict)
+
+    def register(
+        self,
+        pydantic_model: Union[pydantic.BaseModel, pydantic.main.ModelMetaclass],
+        field: str,
+        magicgui_factory: Callable = None,
+        magicgui_args: Optional[tuple] = None,
+        magicgui_kwargs: Optional[dict] = None,
+        pydantic_attr_factory: Callable = None,
+        pydantic_attr_args: Optional[tuple] = None,
+        pydantic_attr_kwargs: Optional[dict] = None,
+    ):
+        """
+
+        Parameters
+        ----------
+        pydantic_model :
+            the pydantic model to register
+        field :
+            the attribute from the pydantic model to register
+        magicgui_factory :
+            a callable function that must return a magicgui widget
+        magicgui_args :
+            a tuple containing arguments to magicgui_factory
+        magicgui_kwargs :
+            a dict containing keyword arguments to magicgui_factory
+        pydantic_attr_factory :
+            a function that takes a magicgui widget instance and returns the
+            arguments for a pydantic attribute
+        pydantic_attr_args :
+            a tuple containing arguments to pydantic_attr_factory
+        pydantic_attr_kwargs :
+            a dict containing keyword arguments to pydantic_attr_factory
+        """
+        magicgui_args = set_default(magicgui_args, ())
+        magicgui_kwargs = set_default(magicgui_kwargs, {})
+        pydantic_attr_args = set_default(pydantic_attr_args, ())
+        pydantic_attr_kwargs = set_default(pydantic_attr_kwargs, {})
+
+        self.registry[pydantic_model][field] = {}
+        new_entry = {
+            "magicgui": (magicgui_factory, magicgui_args, magicgui_kwargs),
+            "pydantic": (
+                pydantic_attr_factory,
+                pydantic_attr_args,
+                pydantic_attr_kwargs,
+            ),
+        }
+
+        self.registry[pydantic_model][field] = new_entry
+
+    def is_registered(self, pydantic_model, field: str, required: bool = False):
+        # check if a pydantic model and field is registered, will error if required=True
+
+        in_registry = False
+        model_exists = False
+        if pydantic_model in self.registry:
+            model_exists = True
+            in_registry = field in self.registry[pydantic_model]
+
+        if required:
+            if model_exists is False:
+                raise KeyError(f"registry does not contain {pydantic_model}.")
+            elif in_registry is False:
+                raise KeyError(f"{pydantic_model} registry does not contain {field}.")
+
+        return in_registry
+
+    def get_widget_instance(self, pydantic_model, field: str):
+        # return a widget instance for a given pydantic model and field
+        if self.is_registered(pydantic_model, field, required=True):
+            func, args, kwargs = self.registry[pydantic_model][field]["magicgui"]
+            return func(*args, **kwargs)
+
+    def get_pydantic_attr(self, pydantic_model, field: str, widget_instance):
+        # given a widget instance, return an object that can be used to set a
+        # pydantic field
+        if self.is_registered(pydantic_model, field, required=True):
+            func, args, kwargs = self.registry[pydantic_model][field]["pydantic"]
+            return func(widget_instance, *args, **kwargs)
+
+
+translator = MagicPydanticRegistry()
+
+# register some data model fields:
+
+
+def get_file_widget(*args, **kwargs):
+    return widgets.FileEdit(*args, **kwargs)
+
+
+def get_filename(file_widget: widgets.FileEdit):
+    return str(file_widget.value)
+
+
+translator.register(
+    _data_model.DataContainer,
+    "filename",
+    magicgui_factory=get_file_widget,
+    magicgui_kwargs={"name": "filename"},
+    pydantic_attr_factory=get_filename,
+)
+
+
+def create_vector_widget(
+    *args,
+    length: int = 3,
+    box_type=float,
+    default_values: Optional[Tuple] = None,
+    **kwargs,
+):
+    if box_type is float:
+        BoxType = widgets.FloatSpinBox
+    else:
+        BoxType = widgets.SpinBox
+    if default_values is None:
+        default_values = [
+            0,
+        ] * length
+    widg_list = [
+        BoxType(label=" ", name=f"x_{i}", value=default_values[i])
+        for i in range(length)
+    ]
+    return widgets.Container(*args, layout="horizontal", widgets=widg_list, **kwargs)
+
+
+def get_vector_kwargs(vector_widget_instance):
+    return tuple(i.value for i in vector_widget_instance)
+
+
+for edge, box_type in zip(
+    ("left_edge", "right_edge", "resolution"), (float, float, int)
+):
+    defs = _data_model.SelectionObject.__fields__[edge].default
+    translator.register(
+        _data_model.SelectionObject,
+        edge,
+        magicgui_factory=create_vector_widget,
+        magicgui_kwargs={
+            "length": 3,
+            "name": edge,
+            "default_values": defs,
+            "box_type": box_type,
+        },
+        pydantic_attr_factory=get_vector_kwargs,
+    )
+
+
+def get_magicguidefault(field_def: pydantic.fields.ModelField):
+    ftype = field_def.type_
+    new_widget_cls, ops = type_map.get_widget_class(
+        None, ftype, dict(name=field_def.name, value=field_def.default)
+    )
+    return new_widget_cls(**ops)
+
+
+def embed_in_list(default_widget_instance):
+    print("hello!")
+    returnval = [
+        default_widget_instance.value,
+    ]
+    print(returnval)
+    return returnval
+
+
+py_model, field = _data_model.SelectionObject, "fields"
+translator.register(
+    py_model,
+    field,
+    magicgui_factory=get_magicguidefault,
+    magicgui_args=(py_model.__fields__[field]),
+    pydantic_attr_factory=embed_in_list,
+)
+
+py_model, field = _data_model.DataContainer, "selections"
+translator.register(
+    py_model,
+    field,
+    magicgui_factory=get_magicguidefault,
+    magicgui_args=(py_model.__fields__[field]),
+    pydantic_attr_factory=embed_in_list,
+)
+
+
+data_container = widgets.Container()
+add_pydantic_to_container(_data_model.DataContainer, data_container)

--- a/src/yt_napari/_gui_utilities.py
+++ b/src/yt_napari/_gui_utilities.py
@@ -237,11 +237,9 @@ def get_magicguidefault(field_def: pydantic.fields.ModelField):
 
 
 def embed_in_list(default_widget_instance):
-    print("hello!")
     returnval = [
         default_widget_instance.value,
     ]
-    print(returnval)
     return returnval
 
 

--- a/src/yt_napari/_tests/conftest.py
+++ b/src/yt_napari/_tests/conftest.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+import yt
+
+
+@pytest.fixture(scope="session")
+def yt_ugrid_ds_fn(tmpdir_factory):
+
+    # this fixture generates a random yt dataset saved to disk that can be
+    # re-loaded and sampled.
+    arr = np.random.random(size=(64, 64, 64))
+    d = dict(density=(arr, "g/cm**3"), temperature=(arr, "K"))
+    bbox = np.array([[-1.5, 1.5], [-1.5, 1.5], [-1.5, 1.5]])
+    shp = arr.shape
+    ds = yt.load_uniform_grid(d, shp, length_unit="Mpc", bbox=bbox, nprocs=64)
+    ad = ds.all_data()
+    fn = str(tmpdir_factory.mktemp("data").join("uniform_grid_data.h5"))
+    ad.save_as_dataset(
+        fields=[("stream", "density"), ("stream", "temperature")], filename=fn
+    )
+
+    return fn

--- a/src/yt_napari/_tests/test_gui_utilities.py
+++ b/src/yt_napari/_tests/test_gui_utilities.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple, TypeVar
+
 import pydantic
 import pytest
 from magicgui import type_map, widgets
@@ -10,11 +12,25 @@ def test_set_default():
     assert gu.set_default(None, 1) == 1
 
 
-def test_registry():
-    reg = gu.MagicPydanticRegistry()
+@pytest.fixture
+def Model():
+    class LowerModel(pydantic.BaseModel):
+        field_a: float
+        field_b: str = "field_b"
 
-    class Model(pydantic.BaseModel):
+    class TestModel(pydantic.BaseModel):
         field_1: int = 1
+        vec_field1: Tuple[float, float] = (1.0, 2.0)
+        vec_field2: Tuple[float, float, float]
+        bad_field: TypeVar("BadType")
+        low_model: LowerModel
+        multi_low_model: List[LowerModel]
+
+    return TestModel
+
+
+def test_registry(Model):
+    reg = gu.MagicPydanticRegistry()
 
     assert reg.is_registered(Model, "field_1") is False
     with pytest.raises(KeyError):
@@ -45,6 +61,64 @@ def test_registry():
     widget_instance = reg.get_widget_instance(Model, "field_1")
     assert isinstance(widget_instance, widgets.Container)
 
-    func, args, kwargs = reg.registry[Model]["field_1"]["pydantic"]
+    with pytest.raises(KeyError):
+        reg.is_registered(Model, "missing_field", required=True)
+
     pyvalue = reg.get_pydantic_attr(Model, "field_1", widget_instance)
     assert pyvalue == "2_testxyz"
+
+
+def test_yt_widget():
+
+    file_editor = gu.get_file_widget(value="test")
+    assert gu.get_filename(file_editor) == "test"
+
+    values = gu.embed_in_list(file_editor)
+    assert str(values[0]) == "test"
+
+
+def test_pydantic_magicgui_default(Model):
+
+    model_field = Model.__fields__["field_1"]
+    c = gu.get_magicguidefault(model_field)
+    assert c.value == model_field.default
+
+    model_field = Model.__fields__["bad_field"]
+    empty = gu.get_magicguidefault(model_field)
+    assert isinstance(empty, widgets.EmptyWidget)
+
+    tr = gu.MagicPydanticRegistry()
+    c = widgets.Container()
+    with pytest.warns(UserWarning):
+        tr.add_pydantic_to_container(Model, c)
+
+
+def test_pydantic_processing(Model):
+
+    _ = gu._get_pydantic_model_field(Model, "field_1")
+
+    tr = gu.MagicPydanticRegistry()
+
+    def bad_container():
+        return widgets.Container(name="bad_field")
+
+    def get_bad_value(widget_instance):
+        return widget_instance.name
+
+    tr.register(
+        Model,
+        "bad_field",
+        magicgui_factory=bad_container,
+        pydantic_attr_factory=get_bad_value,
+    )
+    c = widgets.Container()
+    tr.add_pydantic_to_container(Model, c)
+    py_kwargs = {}
+    tr.get_pydantic_kwargs(c, Model, py_kwargs)
+    assert py_kwargs["bad_field"] == py_kwargs["bad_field"]
+
+
+def test_yt_data_container():
+    data_container = gu.get_yt_data_container()
+    assert hasattr(data_container, "filename")
+    assert hasattr(data_container.selections, "resolution")

--- a/src/yt_napari/_tests/test_gui_utilities.py
+++ b/src/yt_napari/_tests/test_gui_utilities.py
@@ -1,0 +1,6 @@
+from yt_napari import _gui_utilities as gu
+
+
+def test_set_default():
+    assert gu.set_default(1, None) == 1
+    assert gu.set_default(None, 1) == 1

--- a/src/yt_napari/_tests/test_gui_utilities.py
+++ b/src/yt_napari/_tests/test_gui_utilities.py
@@ -1,6 +1,50 @@
+import pydantic
+import pytest
+from magicgui import type_map, widgets
+
 from yt_napari import _gui_utilities as gu
 
 
 def test_set_default():
     assert gu.set_default(1, None) == 1
     assert gu.set_default(None, 1) == 1
+
+
+def test_registry():
+    reg = gu.MagicPydanticRegistry()
+
+    class Model(pydantic.BaseModel):
+        field_1: int = 1
+
+    assert reg.is_registered(Model, "field_1") is False
+    with pytest.raises(KeyError):
+        _ = reg.is_registered(Model, "field_2", required=True)
+
+    def get_nested_container(nested_value, **kwargs):
+        c = widgets.Container()
+        cls, ops = type_map.get_widget_class(value=nested_value)
+        ops.update(kwargs)
+        print(ops)
+        c.append(cls(value=nested_value, **ops))
+        return c
+
+    def get_value_from_nested(container_widget, extra_string):
+        nested_val = [c.value for c in container_widget][0]
+        return f"{nested_val}_{extra_string}"
+
+    reg.register(
+        Model,
+        "field_1",
+        magicgui_factory=get_nested_container,
+        magicgui_args=(2,),
+        magicgui_kwargs={"name": "testname"},
+        pydantic_attr_factory=get_value_from_nested,
+        pydantic_attr_args=("testxyz",),
+    )
+
+    widget_instance = reg.get_widget_instance(Model, "field_1")
+    assert isinstance(widget_instance, widgets.Container)
+
+    func, args, kwargs = reg.registry[Model]["field_1"]["pydantic"]
+    pyvalue = reg.get_pydantic_attr(Model, "field_1", widget_instance)
+    assert pyvalue == "2_testxyz"

--- a/src/yt_napari/_tests/test_reader.py
+++ b/src/yt_napari/_tests/test_reader.py
@@ -37,25 +37,6 @@ valid_jdict = {
 }
 
 
-@pytest.fixture(scope="session")
-def yt_ugrid_ds_fn(tmpdir_factory):
-
-    # this fixture generates a random yt dataset saved to disk that can be
-    # re-loaded and sampled.
-    arr = np.random.random(size=(64, 64, 64))
-    d = dict(density=(arr, "g/cm**3"), temperature=(arr, "K"))
-    bbox = np.array([[-1.5, 1.5], [-1.5, 1.5], [-1.5, 1.5]])
-    shp = arr.shape
-    ds = yt.load_uniform_grid(d, shp, length_unit="Mpc", bbox=bbox, nprocs=64)
-    ad = ds.all_data()
-    fn = str(tmpdir_factory.mktemp("data").join("uniform_grid_data.h5"))
-    ad.save_as_dataset(
-        fields=[("stream", "density"), ("stream", "temperature")], filename=fn
-    )
-
-    return fn
-
-
 @pytest.fixture
 def json_file_fixture(tmp_path, yt_ugrid_ds_fn):
     # this fixture is the json file for napari to load, with

--- a/src/yt_napari/_tests/test_widget_reader.py
+++ b/src/yt_napari/_tests/test_widget_reader.py
@@ -30,13 +30,12 @@ def test_widget_reader(make_napari_viewer, yt_ugrid_ds_fn):
         return np.random.random(final_shape) * data.mean()
 
     rebuild = partial(rebuild_data, res)
-
-    r.load_data(post_load_function=rebuild)
+    r._post_load_function = rebuild
+    r.load_data()
 
     r.data_container.selections.fields.field_name.value = "temperature"
     r.data_container.selections.left_edge.value = (0.4, 0.4, 0.4)
     r.data_container.selections.right_edge.value = (0.6, 0.6, 0.6)
-    r.load_data(post_load_function=rebuild)
 
     # the viewer should now have two images
     assert len(viewer.layers) == 2

--- a/src/yt_napari/_tests/test_widget_reader.py
+++ b/src/yt_napari/_tests/test_widget_reader.py
@@ -1,0 +1,45 @@
+from functools import partial
+
+import numpy as np
+
+from yt_napari._widget_reader import ReaderWidget
+
+
+def test_widget_reader(make_napari_viewer, yt_ugrid_ds_fn):
+
+    # make_napari_viewer is a pytest fixture. It takes any keyword arguments
+    # that napari.Viewer() takes. The fixture takes care of teardown, do **not**
+    # explicitly close it!
+    viewer = make_napari_viewer()
+
+    r = ReaderWidget(napari_viewer=viewer)
+
+    r.data_container.filename.value = yt_ugrid_ds_fn
+    r.data_container.selections.fields.field_type.value = "gas"
+    r.data_container.selections.fields.field_name.value = "density"
+    res = (10, 10, 10)
+    r.data_container.selections.resolution.value = res
+    r.data_container.edge_units.value = "code_length"
+
+    def rebuild_data(final_shape, data):
+        # the yt file thats being loaded from the pytest fixture is a saved
+        # dataset created from an in-memory uniform grid, and the re-loaded
+        # dataset will not have the full functionality of a ds. so here, we
+        # inject a correctly shaped random array here. If we start using full
+        # test datasets from yt in testing, this should be changed.
+        return np.random.random(final_shape) * data.mean()
+
+    rebuild = partial(rebuild_data, res)
+
+    r.load_data(post_load_function=rebuild)
+
+    r.data_container.selections.fields.field_name.value = "temperature"
+    r.data_container.selections.left_edge.value = (0.4, 0.4, 0.4)
+    r.data_container.selections.right_edge.value = (0.6, 0.6, 0.6)
+    r.load_data(post_load_function=rebuild)
+
+    # the viewer should now have two images
+    assert len(viewer.layers) == 2
+
+    temp_layer = viewer.layers[1]
+    assert temp_layer.metadata["_yt_napari_layer"] is True

--- a/src/yt_napari/_tests/test_widget_reader.py
+++ b/src/yt_napari/_tests/test_widget_reader.py
@@ -36,6 +36,7 @@ def test_widget_reader(make_napari_viewer, yt_ugrid_ds_fn):
     r.data_container.selections.fields.field_name.value = "temperature"
     r.data_container.selections.left_edge.value = (0.4, 0.4, 0.4)
     r.data_container.selections.right_edge.value = (0.6, 0.6, 0.6)
+    r.load_data()
 
     # the viewer should now have two images
     assert len(viewer.layers) == 2

--- a/src/yt_napari/_widget_reader.py
+++ b/src/yt_napari/_widget_reader.py
@@ -17,6 +17,7 @@ class ReaderWidget(QWidget):
         self.big_container = widgets.Container()
         self.data_container = _gui_utilities.get_yt_data_container()
         self.big_container.append(self.data_container)
+        self._post_load_function: Optional[Callable] = None
 
         pb = widgets.PushButton(text="Load")
         pb.clicked.connect(self.load_data)
@@ -31,7 +32,7 @@ class ReaderWidget(QWidget):
             self._yt_scene = Scene()
         return self._yt_scene
 
-    def load_data(self, post_load_function: Optional[Callable] = None):
+    def load_data(self):
         # first extract all the pydantic arguments from the container
         py_kwargs = {}
         _gui_utilities.translator.get_pydantic_kwargs(
@@ -54,8 +55,8 @@ class ReaderWidget(QWidget):
         )
         data, im_kwargs, _ = ref_layer.align_sanitize_layer(layer_list[0])
 
-        if post_load_function is not None:
-            data = post_load_function(data)
+        if self._post_load_function is not None:
+            data = self._post_load_function(data)
 
         # set the metadata
         take_log = model.data[0].selections[0].fields[0].take_log

--- a/src/yt_napari/_widget_reader.py
+++ b/src/yt_napari/_widget_reader.py
@@ -1,0 +1,39 @@
+from typing import Union
+
+import magicgui
+import napari
+import qtpy
+from magicgui import magic_factory
+from qtpy.QtWidgets import QWidget
+
+# example_plugin.some_module
+Widget = Union["magicgui.widgets.Widget", "qtpy.QtWidgets.QWidget"]
+
+
+class MyWidget(QWidget):
+    """Any QtWidgets.QWidget or magicgui.widgets.Widget subclass can be used."""
+
+    def __init__(self, viewer: "napari.viewer.Viewer", parent=None):
+        super().__init__(parent)
+
+
+@magic_factory
+def widget_factory(
+    image: "napari.types.ImageData", threshold: int
+) -> "napari.types.LabelsData":
+    """Generate thresholded image.
+
+    This pattern uses magicgui.magic_factory directly to turn a function
+    into a callable that returns a widget.
+    """
+    return (image > threshold).astype(int)
+
+
+def threshold(
+    image: "napari.types.ImageData", threshold: int
+) -> "napari.types.LabelsData":
+    """Generate thresholded image.
+
+    This function will be turned into a widget using `autogenerate: true`.
+    """
+    return (image > threshold).astype(int)

--- a/src/yt_napari/napari.yaml
+++ b/src/yt_napari/napari.yaml
@@ -5,24 +5,13 @@ contributions:
     - id: yt-napari.get_reader
       python_name: yt_napari._reader:napari_get_reader
       title: Open data with yt-napari
-    - id: yt-napari.my_widget
-      title: Open my widget
-      python_name: yt_napari._widget_reader:MyWidget
     - id: yt-napari.threshold_widget
       title: Make threshold widget with magic_factory
       python_name: yt_napari._widget_reader:widget_factory
-    - id: yt-napari.do_threshold
-      title: Perform threshold on image, return new image
-      python_name: yt_napari._widget_reader:threshold
   readers:
     - command: yt-napari.get_reader
       accepts_directories: false
       filename_patterns: ['*.json']
   widgets:
-    - command: yt-napari.my_widget
-      display_name: yt Reader
     - command: yt-napari.threshold_widget
-      display_name: Threshold
-    - command: yt-napari.do_threshold
-      display_name: Threshold doer
-      autogenerate: true
+      display_name: yt Reader

--- a/src/yt_napari/napari.yaml
+++ b/src/yt_napari/napari.yaml
@@ -4,8 +4,25 @@ contributions:
   commands:
     - id: yt-napari.get_reader
       python_name: yt_napari._reader:napari_get_reader
-      title: Open data with yt-napari  
+      title: Open data with yt-napari
+    - id: yt-napari.my_widget
+      title: Open my widget
+      python_name: yt_napari._widget_reader:MyWidget
+    - id: yt-napari.threshold_widget
+      title: Make threshold widget with magic_factory
+      python_name: yt_napari._widget_reader:widget_factory
+    - id: yt-napari.do_threshold
+      title: Perform threshold on image, return new image
+      python_name: yt_napari._widget_reader:threshold
   readers:
     - command: yt-napari.get_reader
       accepts_directories: false
       filename_patterns: ['*.json']
+  widgets:
+    - command: yt-napari.my_widget
+      display_name: yt Reader
+    - command: yt-napari.threshold_widget
+      display_name: Threshold
+    - command: yt-napari.do_threshold
+      display_name: Threshold doer
+      autogenerate: true

--- a/src/yt_napari/napari.yaml
+++ b/src/yt_napari/napari.yaml
@@ -5,13 +5,13 @@ contributions:
     - id: yt-napari.get_reader
       python_name: yt_napari._reader:napari_get_reader
       title: Open data with yt-napari
-    - id: yt-napari.threshold_widget
-      title: Make threshold widget with magic_factory
-      python_name: yt_napari._widget_reader:widget_factory
+    - id: yt-napari.reader_widget
+      title: Read in a selection of data from yt
+      python_name: yt_napari._widget_reader:ReaderWidget
   readers:
     - command: yt-napari.get_reader
       accepts_directories: false
       filename_patterns: ['*.json']
   widgets:
-    - command: yt-napari.threshold_widget
+    - command: yt-napari.reader_widget
       display_name: yt Reader


### PR DESCRIPTION
**Update**:

The dock widget is now being generated automatically from the pydantic model! Here's a video of it in action: https://youtu.be/9oSnJjS_UW8 and a new screenshot:

![yt-napari dock widget](https://user-images.githubusercontent.com/22038879/163624441-dbe3c185-1d98-478b-8186-c5f9381e1524.png)

The widget is a full `Qwidget` with an embedded magicgui `Container` populated with widgets from the pydantic model. The `load` button callback parses that `Container`, instantiates a pydantic model and then using the same ingestion routines as the load-from-json to extract data.

**Old**:

Working on adding a widget for loading data. 

The initial push has a very basic manual reader that nominally works but I see just as a starting point:

![Screenshot from 2022-03-30 16-40-35](https://user-images.githubusercontent.com/22038879/160936977-a17e816a-0237-4756-9977-0a8cdf0f1e71.png)

I'd like to better automate the plugin fields, for which I see two options to explore initially:

1. Could use a full Qwidget (https://napari.org/plugins/guides.html#widgets-contribution-guide) 
2. Might be able to register the `yt_napari._data_model` pydantic classes with magicgui to map these classes to widget types (https://napari.org/magicgui/usage/types_widgets.html) and then we could use those classes in the `widget_factory` function. 

My initial inclination is to explore the full `Qwidget` route as I think it would allow the potential for adding callbacks that update the widget dynamically (e.g., once a dataset is selected, populate dropdowns with available field types and fields). 


