### PR TITLE
automate schema version naming

### DIFF
--- a/src/yt_napari/_schema_version.py
+++ b/src/yt_napari/_schema_version.py
@@ -1,3 +1,5 @@
-schema_version = "0.2.0"
-schema_version_tuple = (0, 2, 0)
-schema_name = "yt-napari_" + schema_version + ".json"
+from yt_napari._version import version, version_tuple
+
+schema_version_tuple = version_tuple[:3]
+schema_version = ".".join([str(i) for i in schema_version_tuple])
+schema_name = "yt-napari_" + version + ".json"

--- a/src/yt_napari/_tests/_test_json.json
+++ b/src/yt_napari/_tests/_test_json.json
@@ -1,4 +1,4 @@
-{"$schema": "yt-napari_0.2.0.json",
+{"$schema": "yt-napari_0.2.0.dev.json",
  "dataset": [{"filename": "IsolatedGalaxy/galaxy0030/galaxy0030",
            "selections": {
              "regions": [

--- a/src/yt_napari/_tests/_test_json_slice.json
+++ b/src/yt_napari/_tests/_test_json_slice.json
@@ -1,4 +1,4 @@
-{"$schema": "yt-napari_0.2.0.json",
+{"$schema": "yt-napari_0.2.0.dev.json",
   "datasets": [{"filename": "IsolatedGalaxy/galaxy0030/galaxy0030/",
              "selections": {
                "slices": [

--- a/src/yt_napari/_tests/_test_json_timeseries.json
+++ b/src/yt_napari/_tests/_test_json_timeseries.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "yt-napari_0.2.0.json",
+  "$schema": "yt-napari_0.2.0.dev.json",
   "datasets": [],
   "timeseries": [
     {

--- a/src/yt_napari/_tests/_test_json_timeseries_stack.json
+++ b/src/yt_napari/_tests/_test_json_timeseries_stack.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "yt-napari_0.2.0.json",
+  "$schema": "yt-napari_0.2.0.dev.json",
   "datasets": [],
   "timeseries": [
     {

--- a/src/yt_napari/_tests/test_schema_version_comparisons.py
+++ b/src/yt_napari/_tests/test_schema_version_comparisons.py
@@ -24,6 +24,7 @@ def test_version_tupling(string_to_test, expected):
         ("yt-napari_0.0.1.json", True),
         ("yt-napari_1000.1.0.json", False),
         ("/blah/blah/yt-napari_latest.json", True),
+        ("yt-napari_0.2.1.dev.json", True),
     ],
 )
 def test_schema_str_validation(string_to_test, expected):

--- a/src/yt_napari/schemas/_version_comparison.py
+++ b/src/yt_napari/schemas/_version_comparison.py
@@ -23,6 +23,11 @@ def schema_version_is_valid(
 
     # now we check the actual version. since the schema prefix (yt-napari) is
     # in the supplied schema_version, we can assume a form of yt-napari_x.x.x.json
+    # or yt-napari_x.x.x.dev+.json
+    if "dev" in schema_version:
+        ytnapari_log.info("Using development schema.")
+        return True
+
     sc_version = _schema_version_tuple_from_str(schema_version)
     _version_tuple = _get_version_tuple()
     if sc_version < _version_tuple:


### PR DESCRIPTION
This ties the active schema version to the `_version.py` file so that it doesn't have to be manually updated.